### PR TITLE
fix: add missing parameter to ReleaseInfo

### DIFF
--- a/src/apis/git-versions.ts
+++ b/src/apis/git-versions.ts
@@ -12,6 +12,8 @@ export declare class CommitInfo {
 export declare class ReleaseInfo {
     name: string;
 
+    isPreRelease: boolean;
+
     publishedAt: Date;
 
     htmlUrl: string;


### PR DESCRIPTION
The FBW-API returns on GitVersions GetRelease a ReleaseInfo object with the parameter isPreRelease.
isPreRelease parameter is yet missing in the api-client, so this PR adds the parameter to the interface.
